### PR TITLE
Fix a rare index out of bounds panic in the signed difference rasterizer

### DIFF
--- a/src/rasterize.rs
+++ b/src/rasterize.rs
@@ -398,8 +398,8 @@ fn signed_difference_line(mut img: impl ImageMut<Pixel = Scalar>, line: Line) {
         // lower bound of effected x pixels
         let x0_floor = x0.floor().max(0.0);
         let x0i = x0_floor as i32;
-        // uppwer bound of effected x pixels
-        let x1_ceil = x1.ceil();
+        // upper bound of effected x pixels
+        let x1_ceil = x1.ceil().min(width);
         let x1i = x1_ceil as i32;
         if x1i <= x0i + 1 {
             // only goes through one pixel (with the total coverage of `d` spread over two pixels)


### PR DESCRIPTION
Below is a minimal example which reliably panics.
```
use rasterize::*;

fn main() {
    let rasterizer = SignedDifferenceRasterizer::default();
    let fill_rule = FillRule::default();

    let black = LinColor::new(0.0, 0.0, 0.0, 1.0);
    let white = LinColor::new(1.0, 1.0, 1.0, 1.0);

    let size: f64 = 32.0;

    let img = Layer::new(
            BBox::new((0.0, 0.0), (size, size)),
            Some(white),
    );

    let tr = Transform::new_scale(size, size);

    let path = PathBuilder::new()
        .move_to((0.05, 0.0))
        .line_to((1.1554972661390561, 1.1274199761497721))
        .build();

    path.fill(&rasterizer, tr, fill_rule, black, img);  // panics here!
}
```
The bug is caused by floating point rounding errors so the exact values may be architecture dependent.
The panic itself looks like:
> thread '<unnamed>' panicked at 'index out of bounds: the len is 1056 but the index is 1056', /home/luke/.cargo/registry/src/github.com-1ecc6299db9ec823/rasterize-0.1.5/src/rasterize.rs:431:13

Inspecting it in a debugger I found that the problem started at [src/rasterize.rs:395](https://github.com/aslpavel/rasterize/blob/761fa81e7f0c331d23235d6d3a68e420812b54b6/src/rasterize.rs#L395) where rounding errors can cause `x_next` to be set to a value very slightly greater than `width` while the rest of the code assumes that it will always be `<= width`.
For example, `width = 32.0` while `x_next = 32.000000000000028`.
That causes the `ceil()` at [src/rasterize.rs:402](https://github.com/aslpavel/rasterize/blob/761fa81e7f0c331d23235d6d3a68e420812b54b6/src/rasterize.rs#L402) to bump it up to the next integer, then later that value is used to index into the pixel array, causing it to panic.

The fix just involves clipping the value so it can't exceed `width`.