### PR TITLE
Fix infinite loop + memory leak when flattening a segment with a NaN point

### DIFF
--- a/src/curve.rs
+++ b/src/curve.rs
@@ -1097,6 +1097,16 @@ impl Segment {
         }
         result
     }
+
+    pub fn is_nan(&self) -> bool {
+        match self {
+            Segment::Line(line) => line.0.as_slice(),
+            Segment::Quad(quad) => quad.0.as_slice(),
+            Segment::Cubic(cubic) => cubic.0.as_slice(),
+        }
+        .iter()
+        .any(|point| point.0.iter().any(|f| f.is_nan()))
+    }
 }
 
 impl fmt::Debug for Segment {

--- a/src/path.rs
+++ b/src/path.rs
@@ -663,6 +663,9 @@ impl<'a> Iterator for PathFlattenIter<'a> {
         loop {
             match self.stack.pop() {
                 Some(segment) => {
+                    if segment.is_nan() {
+                        panic!("cannot flatten segment with NaN");
+                    }
                     if segment.flatness() < self.flatness {
                         return Some(Line::new(segment.start(), segment.end()));
                     }


### PR DESCRIPTION
Fixes #11 
